### PR TITLE
Added missing const qualifier to TopologyReader::Link::Attributes{Begin,End}()

### DIFF
--- a/src/topology-read/model/topology-reader.cc
+++ b/src/topology-read/model/topology-reader.cc
@@ -155,12 +155,12 @@ TopologyReader::Link::SetAttribute (const std::string &name, const std::string &
 }
 
 TopologyReader::Link::ConstAttributesIterator
-TopologyReader::Link::AttributesBegin (void)
+TopologyReader::Link::AttributesBegin (void) const
 {
   return m_linkAttr.begin ();
 }
 TopologyReader::Link::ConstAttributesIterator
-TopologyReader::Link::AttributesEnd (void)
+TopologyReader::Link::AttributesEnd (void) const
 {
   return m_linkAttr.end ();
 }

--- a/src/topology-read/model/topology-reader.h
+++ b/src/topology-read/model/topology-reader.h
@@ -114,12 +114,12 @@ public:
      * \brief Returns an iterator to the begin of the attributes.
      * \return a const iterator to the first attribute of a link.
      */
-    ConstAttributesIterator AttributesBegin (void);
+    ConstAttributesIterator AttributesBegin (void) const;
     /**
      * \brief Returns an iterator to the end of the attributes.
      * \return a const iterator to the last attribute of a link.
      */
-    ConstAttributesIterator AttributesEnd (void);
+    ConstAttributesIterator AttributesEnd (void) const;
 
 private:
     Link ();


### PR DESCRIPTION
This PR fixes a problem I ran into when using AttributesBegin/End as follows:

```
    TopologyReader::ConstLinksIterator iter = topoFile->LinksBegin();
    for (;iter != topoFile->LinksEnd(); iter++) {

        TopologyReader::Link::ConstAttributesIterator it = iter->AttributesBegin();
        for(;it != iter->AttributesEnd(); it++) {
            std::cout << "Key: " << it->first << " Value: "<< it->second << std::endl;
        }
    }
```

The resulting error was:

```
../scratch/SFL/topology.cc:60:82: error: passing ‘const ns3::TopologyReader::Link’ as ‘this’ argument of ‘ns3::TopologyReader::Link::ConstAttributesIterator ns3::TopologyReader::Link::AttributesBegin()’ discards qualifiers [-fpermissive]
         TopologyReader::Link::ConstAttributesIterator it = iter->AttributesBegin();
                                                                                  ^
../scratch/SFL/topology.cc:61:40: error: passing ‘const ns3::TopologyReader::Link’ as ‘this’ argument of ‘ns3::TopologyReader::Link::ConstAttributesIterator ns3::TopologyReader::Link::AttributesEnd()’ discards qualifiers [-fpermissive]
         for(;it != iter->AttributesEnd(); it++) {
```
