### PR TITLE
Improvements of pcap handling

### DIFF
--- a/src/network/helper/trace-helper.cc
+++ b/src/network/helper/trace-helper.cc
@@ -170,6 +170,13 @@ PcapHelper::DefaultSink (Ptr<PcapFileWrapper> file, Ptr<const Packet> p)
   file->Write (Simulator::Now (), p);
 }
 
+void
+PcapHelper::SinkWithHeader (Ptr<PcapFileWrapper> file, const Header &header, Ptr<const Packet> p)
+{
+  NS_LOG_FUNCTION (file << p);
+  file->Write (Simulator::Now (), header, p);
+}
+
 AsciiTraceHelper::AsciiTraceHelper ()
 {
   NS_LOG_FUNCTION_NOARGS ();

--- a/src/network/helper/trace-helper.h
+++ b/src/network/helper/trace-helper.h
@@ -50,9 +50,11 @@ public:
     DLT_PPP = 9,
     DLT_RAW = 101,
     DLT_IEEE802_11 = 105,
+    DLT_LINUX_SSL = 113,
     DLT_PRISM_HEADER = 119,
     DLT_IEEE802_11_RADIO = 127,
-    DLT_IEEE802_15_4 = 195
+    DLT_IEEE802_15_4 = 195,
+    DLT_NETLINK = 253
   };
 
   /**
@@ -121,6 +123,18 @@ private:
    * @param p the packet to write
    */
   static void DefaultSink (Ptr<PcapFileWrapper> file, Ptr<const Packet> p);
+
+  /**
+   * This trace sink passes a header separately from the packet to prevent creating a new packet
+   * (for performance reasons)
+   *
+   * @param file the file to write to
+   * @param header header of the packet
+   * @param p the packet to write
+   *
+   * @see DefaultSink
+   */
+  static void SinkWithHeader (Ptr<PcapFileWrapper> file, const Header& header, Ptr<const Packet> p);
 };
 
 template <typename T> void

--- a/src/network/utils/pcap-file-wrapper.cc
+++ b/src/network/utils/pcap-file-wrapper.cc
@@ -121,7 +121,7 @@ PcapFileWrapper::Write (Time t, Ptr<const Packet> p)
 }
 
 void
-PcapFileWrapper::Write (Time t, Header &header, Ptr<const Packet> p)
+PcapFileWrapper::Write (Time t, const Header &header, Ptr<const Packet> p)
 {
   NS_LOG_FUNCTION (this << t << &header << p);
   uint64_t current = t.GetMicroSeconds ();

--- a/src/network/utils/pcap-file-wrapper.h
+++ b/src/network/utils/pcap-file-wrapper.h
@@ -130,7 +130,7 @@ public:
    * \param p Packet to write to the pcap file.
    * 
    */
-  void Write (Time t, Header &header, Ptr<const Packet> p);
+  void Write (Time t, const Header &header, Ptr<const Packet> p);
 
   /**
    * \brief Write the provided data buffer to the pcap file.

--- a/src/network/utils/pcap-file.cc
+++ b/src/network/utils/pcap-file.cc
@@ -417,7 +417,7 @@ PcapFile::Write (uint32_t tsSec, uint32_t tsUsec, Ptr<const Packet> p)
 }
 
 void 
-PcapFile::Write (uint32_t tsSec, uint32_t tsUsec, Header &header, Ptr<const Packet> p)
+PcapFile::Write (uint32_t tsSec, uint32_t tsUsec, const Header &header, Ptr<const Packet> p)
 {
   NS_LOG_FUNCTION (this << tsSec << tsUsec << &header << p);
   uint32_t headerSize = header.GetSerializedSize ();

--- a/src/network/utils/pcap-file.h
+++ b/src/network/utils/pcap-file.h
@@ -95,7 +95,7 @@ public:
    * PCAP_PPP, PCAP_80211, etc.  If you are storing different kinds of packet
    * data, such as naked TCP headers, you are at liberty to locally define your
    * own data link types.  According to the pcap-linktype man page, "well-known"
-   * pcap linktypes range from 0 to 177.  If you use a large random number for
+   * pcap linktypes range from 0 to 263.  If you use a large random number for
    * your type, chances are small for a collision.
    *
    * \param snapLen An optional maximum size for packets written to the file.
@@ -147,7 +147,7 @@ public:
    * \param p           Packet to write
    * 
    */
-  void Write (uint32_t tsSec, uint32_t tsUsec, Header &header, Ptr<const Packet> p);
+  void Write (uint32_t tsSec, uint32_t tsUsec, const Header &header, Ptr<const Packet> p);
 
 
   /**
@@ -337,6 +337,10 @@ private:
   void WriteFileHeader (void);
   /**
    * \brief Write a Pcap packet header
+   *
+   * The pcap header has a fixed length of 24 bytes. The last 4 bytes
+   * represent the link-layer type
+   *
    * \param tsSec Time stamp (seconds part)
    * \param tsUsec Time stamp (microseconds part)
    * \param totalLen total packet length

--- a/src/test/ns3tcp/ns3tcp-interop-test-suite.cc
+++ b/src/test/ns3tcp/ns3tcp-interop-test-suite.cc
@@ -157,15 +157,10 @@ Ns3TcpInteroperabilityTestCase::Ipv4L3Tx (std::string context, Ptr<const Packet>
       Time tNow = Simulator::Now ();
       int64_t tMicroSeconds = tNow.GetMicroSeconds ();
 
-      uint32_t size = p->GetSize ();
-      uint8_t *buf = new uint8_t[size];
-      p->CopyData (buf, size);
-
       m_pcapFile.Write (uint32_t (tMicroSeconds / 1000000), 
                         uint32_t (tMicroSeconds % 1000000), 
-                        buf, 
-                        size);
-      delete [] buf;
+                        p
+                        );
     }
   else
     {

--- a/src/test/ns3tcp/ns3tcp-loss-test-suite.cc
+++ b/src/test/ns3tcp/ns3tcp-loss-test-suite.cc
@@ -166,15 +166,11 @@ Ns3TcpLossTestCase::Ipv4L3Tx (std::string context, Ptr<const Packet> packet, Ptr
       Time tNow = Simulator::Now ();
       int64_t tMicroSeconds = tNow.GetMicroSeconds ();
 
-      uint32_t size = p->GetSize ();
-      uint8_t *buf = new uint8_t[size];
-      p->CopyData (buf, size);
 
       m_pcapFile.Write (uint32_t (tMicroSeconds / 1000000), 
                         uint32_t (tMicroSeconds % 1000000), 
-                        buf, 
-                        size);
-      delete [] buf;
+                        p
+                        );
     }
   else
     {

--- a/src/test/ns3tcp/ns3tcp-state-test-suite.cc
+++ b/src/test/ns3tcp/ns3tcp-state-test-suite.cc
@@ -170,15 +170,9 @@ Ns3TcpStateTestCase::Ipv4L3Tx (std::string context, Ptr<const Packet> packet, Pt
       Time tNow = Simulator::Now ();
       int64_t tMicroSeconds = tNow.GetMicroSeconds ();
 
-      uint32_t size = p->GetSize ();
-      uint8_t *buf = new uint8_t[size];
-      p->CopyData (buf, size);
-
       m_pcapFile.Write (uint32_t (tMicroSeconds / 1000000), 
                         uint32_t (tMicroSeconds % 1000000), 
-                        buf, 
-                        size);
-      delete [] buf;
+                        p);
     }
   else
     {


### PR DESCRIPTION
When writing a Header to pcap, it should not be modified and thus be
passed as a constant.

Adds a sink to export Header along the packet for performance reasons (prevent creating a new Packet).

I've also simplified some tests to remove unnecessary data copy.