### PR TITLE
Flush write operations to pcap in debug profile

### DIFF
--- a/src/network/utils/pcap-file.cc
+++ b/src/network/utils/pcap-file.cc
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- * 
+ *
  * Author:  Craig Dowell (craigdo@ee.washington.edu)
  */
 
@@ -28,8 +28,9 @@
 #include "ns3/buffer.h"
 #include "pcap-file.h"
 #include "ns3/log.h"
+#include "ns3/build-profile.h"
 //
-// This file is used as part of the ns-3 test framework, so please refrain from 
+// This file is used as part of the ns-3 test framework, so please refrain from
 // adding any ns-3 specific constructs such as Packet to this file.
 //
 
@@ -62,19 +63,19 @@ PcapFile::~PcapFile ()
 }
 
 
-bool 
+bool
 PcapFile::Fail (void) const
 {
   NS_LOG_FUNCTION (this);
   return m_file.fail ();
 }
-bool 
+bool
 PcapFile::Eof (void) const
 {
   NS_LOG_FUNCTION (this);
   return m_file.eof ();
 }
-void 
+void
 PcapFile::Clear (void)
 {
   NS_LOG_FUNCTION (this);
@@ -159,7 +160,7 @@ PcapFile::Swap (uint16_t val)
   return ((val >> 8) & 0x00ff) | ((val << 8) & 0xff00);
 }
 
-uint32_t 
+uint32_t
 PcapFile::Swap (uint32_t val)
 {
   NS_LOG_FUNCTION (this << val);
@@ -198,7 +199,7 @@ PcapFile::WriteFileHeader (void)
   // at the start of the file.
   //
   m_file.seekp (0, std::ios::beg);
- 
+
   //
   // We have the ability to write out the pcap file header in a foreign endian
   // format, so we need a temp place to swap on the way out.
@@ -265,7 +266,7 @@ PcapFile::ReadAndVerifyFileHeader (void)
   // swapped versions of the standard magic number, and normal and byte swapped
   // versions of the magic number indicating nanosecond resolution timestamps.
   //
-  if (m_fileHeader.m_magicNumber != MAGIC && m_fileHeader.m_magicNumber != SWAPPED_MAGIC && 
+  if (m_fileHeader.m_magicNumber != MAGIC && m_fileHeader.m_magicNumber != SWAPPED_MAGIC &&
       m_fileHeader.m_magicNumber != NS_MAGIC && m_fileHeader.m_magicNumber != NS_SWAPPED_MAGIC)
     {
       m_file.setstate (std::ios::failbit);
@@ -275,7 +276,7 @@ PcapFile::ReadAndVerifyFileHeader (void)
   // If the magic number is swapped, then we can assume that everything else we read
   // is swapped.
   //
-  m_swapMode = (m_fileHeader.m_magicNumber == SWAPPED_MAGIC 
+  m_swapMode = (m_fileHeader.m_magicNumber == SWAPPED_MAGIC
                 || m_fileHeader.m_magicNumber == NS_SWAPPED_MAGIC) ? true : false;
 
   if (m_swapMode)
@@ -292,7 +293,7 @@ PcapFile::ReadAndVerifyFileHeader (void)
     }
 
   //
-  // A quick test of reasonablness for the time zone offset corresponding to 
+  // A quick test of reasonablness for the time zone offset corresponding to
   // a real place on the planet.
   //
   if (m_fileHeader.m_zone < -12 || m_fileHeader.m_zone > 12)
@@ -397,6 +398,7 @@ PcapFile::WritePacketHeader (uint32_t tsSec, uint32_t tsUsec, uint32_t totalLen)
   m_file.write ((const char *)&header.m_tsUsec, sizeof(header.m_tsUsec));
   m_file.write ((const char *)&header.m_inclLen, sizeof(header.m_inclLen));
   m_file.write ((const char *)&header.m_origLen, sizeof(header.m_origLen));
+  NS_BUILD_DEBUG(m_file.flush());
   return inclLen;
 }
 
@@ -406,14 +408,16 @@ PcapFile::Write (uint32_t tsSec, uint32_t tsUsec, uint8_t const * const data, ui
   NS_LOG_FUNCTION (this << tsSec << tsUsec << &data << totalLen);
   uint32_t inclLen = WritePacketHeader (tsSec, tsUsec, totalLen);
   m_file.write ((const char *)data, inclLen);
+  NS_BUILD_DEBUG(m_file.flush());
 }
 
-void 
+void
 PcapFile::Write (uint32_t tsSec, uint32_t tsUsec, Ptr<const Packet> p)
 {
   NS_LOG_FUNCTION (this << tsSec << tsUsec << p);
   uint32_t inclLen = WritePacketHeader (tsSec, tsUsec, p->GetSize ());
   p->CopyData (&m_file, inclLen);
+  NS_BUILD_DEBUG(m_file.flush());
 }
 
 void 
@@ -435,11 +439,11 @@ PcapFile::Write (uint32_t tsSec, uint32_t tsUsec, const Header &header, Ptr<cons
 
 void
 PcapFile::Read (
-  uint8_t * const data, 
+  uint8_t * const data,
   uint32_t maxBytes,
-  uint32_t &tsSec, 
-  uint32_t &tsUsec, 
-  uint32_t &inclLen, 
+  uint32_t &tsSec,
+  uint32_t &tsUsec,
+  uint32_t &inclLen,
   uint32_t &origLen,
   uint32_t &readLen)
 {
@@ -473,7 +477,7 @@ PcapFile::Read (
   origLen = header.m_origLen;
 
   //
-  // We don't always want to force the client to keep a maximum length buffer 
+  // We don't always want to force the client to keep a maximum length buffer
   // around so we allow her to specify a minimum number of bytes to read.
   // Usually 64 bytes is enough information to print all of the headers, so
   // it isn't typically necessary to read all thousand bytes of an echo packet,
@@ -493,7 +497,7 @@ PcapFile::Read (
 }
 
 bool
-PcapFile::Diff (std::string const & f1, std::string const & f2, 
+PcapFile::Diff (std::string const & f1, std::string const & f2,
                 uint32_t & sec, uint32_t & usec, uint32_t & packets,
                 uint32_t snapLen)
 {
@@ -538,7 +542,7 @@ PcapFile::Diff (std::string const & f1, std::string const & f2,
         }
 
       ++packets;
-      
+
       if (tsSec1 != tsSec2 || tsUsec1 != tsUsec2)
         {
           diff = true; // Next packet timestamps do not match


### PR DESCRIPTION
Otherwise pcaps are not saved if the simulation crashes. Helpful for debugging.

This also removes some trailing spaces and as it is a small patch I let them to improve the codebase.