### PR TITLE
mpi: Fix minor comment error

### DIFF
--- a/src/mpi/examples/simple-distributed.cc
+++ b/src/mpi/examples/simple-distributed.cc
@@ -122,7 +122,7 @@ main (int argc, char *argv[])
   routerNodes.Add (routerNode1);
   routerNodes.Add (routerNode2);
 
-  // Create leaf nodes on left with system id 1
+  // Create leaf nodes on right with system id 1
   NodeContainer rightLeafNodes;
   rightLeafNodes.Create (4, 1);
 


### PR DESCRIPTION
The codes in line number 126 and 127 adds leaf nodes on the right (according to the explanation in the diagram in the top of the source code) with system id 1, defined in previous lines. But the comments written in line number 125 does not describe what the following lines actually do, as it states that leaf nodes were being added to the left which apparently were already been added in previous lines above. This commenting error could cause problems for new users with minimum to no understanding of ns-3 usage. Suitable changes have been made i.e. left was changed to right.