### PR TITLE
 fixed build error in dpdk-net-device

### DIFF
--- a/src/fd-net-device/model/dpdk-net-device.cc
+++ b/src/fd-net-device/model/dpdk-net-device.cc
@@ -410,7 +410,7 @@ DpdkNetDevice::InitDpdk (int argc, char** argv, std::string dpdkDriver)
   CheckAllPortsLinkStatus ();
 
   NS_LOG_INFO ("Launching core threads");
-  rte_eal_mp_remote_launch (LaunchCore, this, CALL_MASTER);
+  rte_eal_mp_remote_launch (LaunchCore, this, CALL_MAIN);
 }
 
 uint8_t*


### PR DESCRIPTION
changed CALL_MASTER to CALL_MAIN in dpdk-net-device.cc


```
/home/neru/ns-3-dev-git/src/fd-net-device/model/dpdk-net-device.cc: In member function ‘void ns3::DpdkNetDevice::InitDpdk(int, char**, std::string)’:
/home/neru/ns-3-dev-git/src/fd-net-device/model/dpdk-net-device.cc:413:47: error: ‘CALL_MASTER’ was not declared in this scope; did you mean ‘CALL_MAIN’?
  413 |   rte_eal_mp_remote_launch (LaunchCore, this, CALL_MASTER);
      |                                               ^~~~~~~~~~~
      |                                               CALL_MAIN
make[2]: *** [src/fd-net-device/CMakeFiles/libfd-net-device-obj.dir/build.make:104: src/fd-net-device/CMakeFiles/libfd-net-device-obj.dir/model/dpdk-net-device.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:4246: src/fd-net-device/CMakeFiles/libfd-net-device-obj.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```